### PR TITLE
Mac compatibility

### DIFF
--- a/Project Files/Config.xcconfig
+++ b/Project Files/Config.xcconfig
@@ -1,0 +1,4 @@
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+BUILT_PRODUCTS_DIR = $(SRCROOT)/Build/

--- a/Project Files/Euclide.xcodeproj/project.pbxproj
+++ b/Project Files/Euclide.xcodeproj/project.pbxproj
@@ -244,7 +244,9 @@
 				GCC_MODEL_TUNING = G5;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				INSTALL_PATH = /usr/local/bin;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_NAME = Euclide;
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
@@ -255,36 +257,40 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_MODEL_TUNING = G5;
 				INSTALL_PATH = /usr/local/bin;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_NAME = Euclide;
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};
 		1DEB923608733DC60010E9CD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				ARCHS = "$(ARCHS_STANDARD)";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "";
 				PREBINDING = NO;
-				SDKROOT = macosx10.6;
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
 		1DEB923708733DC60010E9CD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				ARCHS = "$(ARCHS_STANDARD)";
 				CONFIGURATION_BUILD_DIR = ..;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_PREPROCESSOR_DEFINITIONS = NDEBUG;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PREBINDING = NO;
-				SDKROOT = macosx10.6;
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};

--- a/Project Files/Euclide.xcodeproj/project.pbxproj
+++ b/Project Files/Euclide.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2091DBC725FF11DA00B18419 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		8DD76F6C0486A84900D96B5E /* Euclide */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = Euclide; sourceTree = BUILT_PRODUCTS_DIR; };
 		C6859E8B029090EE04C91782 /* Euclide.1 */ = {isa = PBXFileReference; lastKnownFileType = text.man; path = Euclide.1; sourceTree = "<group>"; };
 		CEA9124A11B1568C00B93666 /* Constantes.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Constantes.cpp; sourceTree = "<group>"; };
@@ -96,6 +97,7 @@
 		08FB7794FE84155DC02AAC07 /* Euclide */ = {
 			isa = PBXGroup;
 			children = (
+				2091DBC725FF11DA00B18419 /* Config.xcconfig */,
 				CEA9131D11B162A300B93666 /* libiconv.2.4.0.dylib */,
 				CEA9130E11B1626800B93666 /* libncurses.5.4.dylib */,
 				08FB7795FE84155DC02AAC07 /* Source */,


### PR DESCRIPTION
Le SDK 10.6 ciblé dans le projet n'est plus disponible dans Xcode.
Bonne nouvelle, le code compile sans problème sur les derniers SDK. Et meme sur Apple Silicon pour quand le monde sera prêt pour des processeurs arm sur desktop/laptop.
J'ai ciblé sur le SDK 10.9 qui est le dernier encore maintenu et fournit d'office dans Xcode.

Aussi, Xcode ne supporte plus la compilation vers 32bits depuis 2016. J'ai du changer la cible vers 64 bits également.

Aussi, Xcode semble avoir changé depuis Snow Leopard (2009!!) la façon dont les projets gèrent leur chemin de build.
Maintenant il faut spécifier un path dans un fichier de conf.
Avec cette PR, Xcode va construire le projet dans `Project Files\Build\Releases\euclide`.